### PR TITLE
Fix URL of sgerrand.rsa.pub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir /usr/lib/jvm; \
     tar -zxC /usr/lib/jvm -f graalvm-ce-${GRAALVM_VERSION}-linux-amd64.tar.gz; \
     rm -f graalvm-ce-${GRAALVM_VERSION}-linux-amd64.tar.gz
 
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub \
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
     &&  wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-$GLIBC_VERSION.apk" \
     &&  apk --no-cache add "glibc-$GLIBC_VERSION.apk" \
     &&  rm "glibc-$GLIBC_VERSION.apk" \


### PR DESCRIPTION
## Fixed
* Fix URL of `sgerrand.rsa.pub`

I just replaced https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub with https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub because it was moved. I confirmed that Dockerfile was buildable in local.

Detail is written in [sgerrand/alpine-pkg-glibc]( https://github.com/sgerrand/alpine-pkg-glibc/tree/fc20c32a048060a5478aa579b648bace7364b38f#readme).